### PR TITLE
Changed num <--> bytes conversion according to new Rust syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ merlin = "3.0.0"
 
 thiserror = "1.0"
 displaydoc = "0.2"
+byteorder = "1.4.3"
 
 [dependencies.blake3]
 version = "0.3.8"

--- a/src/proof/tests.rs
+++ b/src/proof/tests.rs
@@ -4,7 +4,7 @@ use smtree::{
 };
 
 #[test]
-fn test_serialization() {
+fn test_new_serialization() {
     let tree_height = 8;
     let num_leaves = 20;
     let batch_size = 10;

--- a/src/range/padding.rs
+++ b/src/range/padding.rs
@@ -39,7 +39,9 @@ impl Serializable for RangeProofPadding {
     fn serialize(&self) -> Vec<u8> {
         let mut result: Vec<u8> = Vec::new();
         let mut bytes = self.get_aggregated().to_bytes();
-        result.append(&mut bytes.len().to_le_bytes().to_vec());
+        result.append(&mut bytes.len()
+        .to_le_bytes()
+        .to_vec());
         result.append(&mut bytes);
         result.append(&mut self.get_individual().len()
         .to_le_bytes()

--- a/src/range/padding.rs
+++ b/src/range/padding.rs
@@ -3,14 +3,13 @@ use curve25519_dalek_ng::{ristretto::CompressedRistretto, scalar::Scalar};
 use smtree::{
     error::DecodingError,
     traits::{Serializable, TypeName},
-    utils::usize_to_bytes,
 };
 use std::cmp::Ordering;
 
 use super::{
     deserialize_aggregated_proof, deserialize_individual_proofs, generate_aggregated_range_proof,
     generate_single_range_proof, verify_aggregated_range_proof, verify_single_range_proof,
-    RangeProvable, RangeVerifiable, INDIVIDUAL_NUM_BYTE_NUM, PROOF_SIZE_BYTE_NUM,
+    RangeProvable, RangeVerifiable,
 };
 
 // RANGE PROOF PADDING
@@ -40,12 +39,12 @@ impl Serializable for RangeProofPadding {
     fn serialize(&self) -> Vec<u8> {
         let mut result: Vec<u8> = Vec::new();
         let mut bytes = self.get_aggregated().to_bytes();
-        result.append(&mut usize_to_bytes(bytes.len(), PROOF_SIZE_BYTE_NUM));
+        result.append(&mut bytes.len().to_le_bytes().to_vec());
         result.append(&mut bytes);
-        result.append(&mut usize_to_bytes(
-            self.get_individual().len(),
-            INDIVIDUAL_NUM_BYTE_NUM,
-        ));
+        result.append(&mut self.get_individual().len()
+        .to_le_bytes()
+        .to_vec()
+        );
         for proof in self.get_individual() {
             result.append(&mut proof.to_bytes());
         }

--- a/src/range/splitting.rs
+++ b/src/range/splitting.rs
@@ -4,14 +4,12 @@ use curve25519_dalek_ng::{ristretto::CompressedRistretto, scalar::Scalar};
 use smtree::{
     error::DecodingError,
     traits::{Serializable, TypeName},
-    utils::usize_to_bytes,
 };
 
 use super::{
     deserialize_aggregated_proof, deserialize_individual_proofs, generate_aggregated_range_proof,
     generate_single_range_proof, verify_aggregated_range_proof, verify_single_range_proof,
-    RangeProvable, RangeVerifiable, AGGREGATED_NUM_BYTE_NUM, INDIVIDUAL_NUM_BYTE_NUM,
-    PROOF_SIZE_BYTE_NUM,
+    RangeProvable, RangeVerifiable, AGGREGATED_NUM_BYTE_NUM,
 };
 
 // RANGE PROOF SPLITTING
@@ -38,20 +36,20 @@ impl Serializable for RangeProofSplitting {
     fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         // append aggregated proofs to the result
-        result.append(&mut usize_to_bytes(
-            self.get_aggregated().len(),
-            AGGREGATED_NUM_BYTE_NUM,
-        ));
+        result.append(&mut self.get_individual().len()
+        .to_le_bytes()
+        .to_vec()
+        );
         for proof in self.get_aggregated() {
             let mut bytes = proof.to_bytes();
-            result.append(&mut usize_to_bytes(bytes.len(), PROOF_SIZE_BYTE_NUM));
+            result.append(&mut bytes.len().to_le_bytes().to_vec());
             result.append(&mut bytes);
         }
         // append individual proofs to the result
-        result.append(&mut usize_to_bytes(
-            self.get_individual().len(),
-            INDIVIDUAL_NUM_BYTE_NUM,
-        ));
+        result.append(&mut self.get_individual().len()
+        .to_le_bytes()
+        .to_vec()
+        );
         for proof in self.get_individual() {
             result.append(&mut proof.to_bytes());
         }

--- a/src/range/splitting.rs
+++ b/src/range/splitting.rs
@@ -5,6 +5,7 @@ use smtree::{
     error::DecodingError,
     traits::{Serializable, TypeName},
 };
+use byteorder::{LittleEndian, ByteOrder};
 
 use super::{
     deserialize_aggregated_proof, deserialize_individual_proofs, generate_aggregated_range_proof,
@@ -36,10 +37,10 @@ impl Serializable for RangeProofSplitting {
     fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         // append aggregated proofs to the result
-        result.append(&mut self.get_individual().len()
-        .to_le_bytes()
-        .to_vec()
-        );
+        let len = self.get_individual().len() as u16;  // Ensure the length fits into 2 bytes
+        let mut buf = [0; 2];
+        LittleEndian::write_u16(&mut buf, len);
+        result.extend_from_slice(&buf);
         for proof in self.get_aggregated() {
             let mut bytes = proof.to_bytes();
             result.append(&mut bytes.len().to_le_bytes().to_vec());

--- a/src/range/splitting.rs
+++ b/src/range/splitting.rs
@@ -5,7 +5,6 @@ use smtree::{
     error::DecodingError,
     traits::{Serializable, TypeName},
 };
-use byteorder::{LittleEndian, ByteOrder};
 
 use super::{
     deserialize_aggregated_proof, deserialize_individual_proofs, generate_aggregated_range_proof,
@@ -37,13 +36,16 @@ impl Serializable for RangeProofSplitting {
     fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         // append aggregated proofs to the result
-        let len = self.get_individual().len() as u16;  // Ensure the length fits into 2 bytes
-        let mut buf = [0; 2];
-        LittleEndian::write_u16(&mut buf, len);
-        result.extend_from_slice(&buf);
+        let len=self.get_aggregated().len() as u16;
+        result.append(&mut len
+        .to_le_bytes()
+        .to_vec()
+        );
         for proof in self.get_aggregated() {
             let mut bytes = proof.to_bytes();
-            result.append(&mut bytes.len().to_le_bytes().to_vec());
+            result.append(&mut bytes.len()
+            .to_le_bytes()
+            .to_vec());
             result.append(&mut bytes);
         }
         // append individual proofs to the result


### PR DESCRIPTION
Changed the num to bytes conversion (Little Endian) according to the latest Rust syntax. However, deserialization is left. @Stentonian wanted your thoughts on this as the deserialization involves other libraries as well, where I'll have to implement ```from_le_bytes``` separately. A bit more effort than the current PR, but doable. Should I have a go at it?