### PR TITLE
Daniel/printing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ curve25519-dalek-ng = "4.1.1"
 thiserror = "1.0"
 displaydoc = "0.2"
 
+hex = "0.4.3"
+
 [dev-dependencies]
 criterion = "0.4.0"
 

--- a/src/calc_hash.rs
+++ b/src/calc_hash.rs
@@ -1,0 +1,17 @@
+
+use dapol::{NdmSmt, User, UserId, D256};
+use crate::H256Finalizable;
+
+fn main() {
+    let hash = {
+        let mut hasher = H256Finalizable::new();
+        hasher.update("0x28cddc853d5bfea98a5bc68949ff040a398d17c41f1fcbe023b0b4db143e650c".as_bytes());
+        hasher.update("0x12e4abcff6d2443182b2610aea518b40b997cbaacc910bf6f3e01098c896446f".as_bytes());
+        hasher.update("0x5f52520131e8c7fb80c9c75f836d73185d96a52dca93da41d659765f31145e35".as_bytes());
+        hasher.update("0xb350807c0419757ffb77da7ed7c257eccb2896d4cafce61811814344676aae96".as_bytes());
+        hasher.finalize_as_h256() // TODO do a unit test that compares the output of this to a different piece of code
+    };
+
+    println!("0x29470e0396c988739573d25aaeefb0c33bfb013acfa6f6de0065d55170f8642d");
+    println!("{:?}", hash);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,6 @@ fn main() {
     let ndsmt = NdmSmt::new(master_secret, salt_b, salt_s, height, users).unwrap();
     ndsmt.print_tree();
 
-    //let proof = ndsmt.generate_inclusion_proof(&UserId::from_str("user1 ID").unwrap()).unwrap();
-    //println!("{:?}", proof);
+    let proof = ndsmt.generate_inclusion_proof(&UserId::from_str("user1 ID").unwrap()).unwrap();
+    proof.print_proof();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,32 @@
 use std::str::FromStr;
 
-use dapol::{NdmSmt, User, D256, UserId};
+use dapol::{NdmSmt, User, UserId, D256};
 
 fn main() {
-    let user1 = User{
+    let user1 = User {
         liability: 10u64,
         id: UserId::from_str("user1 ID").unwrap(),
+    };
+
+    let user2 = User {
+        liability: 20u64,
+        id: UserId::from_str("user2 ID").unwrap(),
+    };
+
+    let user4 = User {
+        liability: 40u64,
+        id: UserId::from_str("user4 ID").unwrap(),
     };
 
     let master_secret: D256 = D256::from(3u64);
     let salt_b: D256 = D256::from(5u64);
     let salt_s: D256 = D256::from(7u64);
-    let height: u8 = 5u8;
-    let users: Vec<User> = vec![user1];
-    let ndsmt = NdmSmt::new(master_secret, salt_b, salt_s, height, users).unwrap();
+    let height: u8 = 3u8;
+    let users: Vec<User> = vec![user1, user2, user4];
 
-    let proof = ndsmt.generate_inclusion_proof(&UserId::from_str("user1 ID").unwrap()).unwrap();
-    println!("{:?}", proof);
+    let ndsmt = NdmSmt::new(master_secret, salt_b, salt_s, height, users).unwrap();
+    ndsmt.print_tree();
+
+    //let proof = ndsmt.generate_inclusion_proof(&UserId::from_str("user1 ID").unwrap()).unwrap();
+    //println!("{:?}", proof);
 }


### PR DESCRIPTION
Playing with the code a bit.

To better see the content of a tree and an inclusion proof. Created print functions for each. Inclusion proof show all the available info of a hidden node a user will need to be able to verify himself through a tree.

Sorry about the auto formatting moving line around.

tree data:
treeheight 3

root.coord Coordinate { y: 2, x: 0 }
root.content.liability 70
root.content.blinding_factor 0x9e11d80b04d58c157f03a475fe9e4f5e5cb2c346144950edc1fff5f7526c7b01
root.content.commitment 0xb487e095158f907445711721f665b12085f4d43545063b4936e5bfdfd0266511
root.content.hash 0x622e62b18d3e69d40e8b1de38705071145d5e320be592b641c9ea771541c4f09

node.coord Coordinate { y: 0, x: 2 }
node.content.liability 10
node.content.blinding_factor 0x34894d26927238b0e3bddc88a95bb38366e85ef85fcfa1875855c3d8604f8c0b
node.content.commitment 0x2499cfe710c92196a8c75aa7615eeb063affc967b77924b08f1df2a8c1ee251d
node.content.hash 0x3410e66cf35842b7e0c5eff16968c36a8664f318de79d287da966f4c6f683889

node.coord Coordinate { y: 2, x: 0 }
node.content.liability 70
node.content.blinding_factor 0x9e11d80b04d58c157f03a475fe9e4f5e5cb2c346144950edc1fff5f7526c7b01
node.content.commitment 0xb487e095158f907445711721f665b12085f4d43545063b4936e5bfdfd0266511
node.content.hash 0x622e62b18d3e69d40e8b1de38705071145d5e320be592b641c9ea771541c4f09

node.coord Coordinate { y: 0, x: 1 }
node.content.liability 20
node.content.blinding_factor 0x4284000c64ff815a15901870352cc1de47158e11f1c6cc1931160482c1797e01
node.content.commitment 0x12e4abcff6d2443182b2610aea518b40b997cbaacc910bf6f3e01098c896446f
node.content.hash 0xb350807c0419757ffb77da7ed7c257eccb2896d4cafce61811814344676aae96

node.coord Coordinate { y: 0, x: 0 }
node.content.liability 40
node.content.blinding_factor 0x7e57a1591b69c57da7397531c8c664c637789cab5959f408933d429b3a0d7d01
node.content.commitment 0x88ed8c74006942f7c9a2981fd9e144d78f01c225c3218992aa73e8bade03923b
node.content.hash 0xd48fd34afe2ca99fcb1294ffee9641e71800dc7666c7a823ed8d8c50bd178105

node.coord Coordinate { y: 0, x: 3 }
node.content.liability 0
node.content.blinding_factor 0x9780dedc0c5d1fe5b41831ee354a554a763c3a916959ed42a556ec01f695f302
node.content.commitment 0x16582ffbb40f774cd05d0fa9158aebb1bd7e5d3563ff1477bcfafec4b3c58134
node.content.hash 0xeb9eb3e462728068632dfc9bb5c568d715a7ff6b85a3c673c5a0c21472523ed8

node.coord Coordinate { y: 1, x: 0 }
node.content.liability 60
node.content.blinding_factor 0xc0dba1657f6847d8bcc98da1fdf225a57f8d2abd4a20c122c453461dfc86fb02
node.content.commitment 0x3ce6ff6debc47d09da89c13114c94ad08e152f5b7e5572052312a9407c9ee04f
node.content.hash 0x54f97fcdafcde979b0968bdd246aeff2888cde278b4a012d7ae79ad979e6e8bf

node.coord Coordinate { y: 1, x: 1 }
node.content.liability 10
node.content.blinding_factor 0xcb092c039fcf579598d60d77dfa508cedc249989c9288fcafdabafda56e57f0e
node.content.commitment 0x8ab0a1b17caf2e76f0fa054f64d2d15da09e74f7afd15ab7f70f12fc80928152
node.content.hash 0xe71c03b8706bf084f191a94893d4d32111cd431499758ae9ef340a3f3849d78d

inclusion proof siblings:

sibling.coord Coordinate { y: 0, x: 3 }
sibling.content.commitment 0x16582ffbb40f774cd05d0fa9158aebb1bd7e5d3563ff1477bcfafec4b3c58134
sibling.content.hash 0xeb9eb3e462728068632dfc9bb5c568d715a7ff6b85a3c673c5a0c21472523ed8

sibling.coord Coordinate { y: 1, x: 0 }
sibling.content.commitment 0x3ce6ff6debc47d09da89c13114c94ad08e152f5b7e5572052312a9407c9ee04f
sibling.content.hash 0x54f97fcdafcde979b0968bdd246aeff2888cde278b4a012d7ae79ad979e6e8bf
